### PR TITLE
Update CMLFormulaOperator.hx

### DIFF
--- a/src/org/si/cml/core/CMLFormulaOperator.hx
+++ b/src/org/si/cml/core/CMLFormulaOperator.hx
@@ -17,7 +17,7 @@ class CMLFormulaOperator extends CMLFormulaElem
 {
         static private  var sin:CMLSinTable = new CMLSinTable();
         
-        static public var prefix_rex :String = "([-!(]|\\$sin|\\$cos|\\$tan|\\$asn|\\$acs|\\$atn|\\$sqr|\\$i\\?|\\$i\\?\\?|\\$int|\\$abs)";
+        static public var prefix_rex :String = "([-!(]|\\$sin|\\$cos|\\$tan|\\$asn|\\$acs|\\$atn|\\$sqr|\\$i\\?\\?|\\$i\\?|\\$int|\\$abs)";
         static public var postfix_rex:String = "(\\))";
 
         public var priorL:Float = 0;


### PR DESCRIPTION
Parsing of i?? must be before i? otherwise it's parsing but can have unexpected behavior. At best considered as 0, at worse no value